### PR TITLE
feat: Init Launch

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -1,8 +1,7 @@
 version: 2.1
 
 description: >
-  Aqua Security Trivy - Ported from GitHub Action
-  NOT OFFICIAL
+  Aqua Security Trivy - Ported from GitHub Action - Unofficial
 display:
   home_url: "https://github.com/aquasecurity/trivy-action"
   source_url: "https://github.com/CircleCI-Labs/trivy"


### PR DESCRIPTION
Launch support for Trivy. Ported over the official GitHub Action from https://github.com/aquasecurity/trivy-action